### PR TITLE
Add additional context for signatures

### DIFF
--- a/esrs2020-extra-0.0.jsonld
+++ b/esrs2020-extra-0.0.jsonld
@@ -1,0 +1,44 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "challenge": "https://w3id.org/security#challenge",
+    "created": {
+      "@id": "http://purl.org/dc/terms/created",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+    },
+    "domain": "https://w3id.org/security#domain",
+    "expires": {
+      "@id": "https://w3id.org/security#expiration",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+    },
+    "jws": "https://w3id.org/security#jws",
+    "nonce": "https://w3id.org/security#nonce",
+    "proofPurpose": {
+      "@id": "https://w3id.org/security#proofPurpose",
+      "@type": "@vocab",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "assertionMethod": {
+          "@id": "https://w3id.org/security#assertionMethod",
+          "@type": "@id",
+          "@container": "@set"
+        },
+        "authentication": {
+          "@id": "https://w3id.org/security#authenticationMethod",
+          "@type": "@id",
+          "@container": "@set"
+        }
+      }
+    },
+    "proofValue": "https://w3id.org/security#proofValue",
+    "verificationMethod": {
+      "@id": "https://w3id.org/security#verificationMethod",
+      "@type": "@id"
+    }
+  }
+}


### PR DESCRIPTION
This is an alternative to https://github.com/decentralized-identity/EcdsaSecp256k1RecoverySignature2020/pull/9, adding the extra context as a separate file rather than updating the existing one. 